### PR TITLE
Fixed Windows Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,10 @@ project (LumaHDRv)
 option(BUILD_TEST_EXAMPLES
   "Build the simple test applications in ./test" ON)
 
-option(LINK_OPENEXR_DLL
-  "Dynamically link against OpenEXR libraries" OFF)
+if (MSVC)
+    option(LINK_OPENEXR_DLL
+      "Dynamically link against OpenEXR libraries" OFF)
+endif (MSVC)
 
 set( CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ project (LumaHDRv)
 option(BUILD_TEST_EXAMPLES
   "Build the simple test applications in ./test" ON)
 
+option(LINK_OPENEXR_DLL
+  "Dynamically link against OpenEXR libraries" OFF)
+
 set( CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake )
 
 if(APPLE)
@@ -209,6 +212,19 @@ if ( HAVE_OPENEXR )
         include_directories ("${PROJECT_SOURCE_DIR}/test")
         add_subdirectory (test)
     endif (BUILD_TEST_EXAMPLES)
+
+    if( LINK_OPENEXR_DLL )
+    
+        target_compile_definitions(lumaenc PRIVATE OPENEXR_DLL)
+        target_compile_definitions(lumadec PRIVATE OPENEXR_DLL)
+
+        if(BUILD_TEST_EXAMPLES)
+            target_compile_definitions(test_simple_enc PRIVATE OPENEXR_DLL)
+            target_compile_definitions(test_simple_dec PRIVATE OPENEXR_DLL)
+        endif(BUILD_TEST_EXAMPLES)
+
+    endif( LINK_OPENEXR_DLL )
+
 endif ( HAVE_OPENEXR )
 
 # lumaplay can only be built if OpenGL is found

--- a/include/luma/luma_decoder.h
+++ b/include/luma/luma_decoder.h
@@ -49,13 +49,21 @@
 #ifndef LUMA_DECODER_H
 #define LUMA_DECODER_H
 
+#ifdef _WINDOWS
+#ifdef luma_decoder_EXPORTS
+#define LUMA_DEC_EXPORT __declspec(dllexport)
+#else
+#define LUMA_DEC_EXPORT __declspec(dllimport)
+#endif
+#else
+#define LUMA_DEC_EXPORT
+#endif
+
 #include "luma_quantizer.h"
 #include "mkv_interface.h"
 
 #include "vpx_decoder.h"
 #include "vp8dx.h"
-
-#include <sys/time.h>
 
 struct LumaDecoderParamsBase
 {
@@ -78,7 +86,7 @@ struct LumaDecoderParamsBase
  *
  */
  
-class LumaDecoderBase
+class LUMA_DEC_EXPORT LumaDecoderBase
 {
 public:
     LumaDecoderBase(const char *inputFile = NULL, bool verbose = 0) : m_input(inputFile)
@@ -132,7 +140,7 @@ struct LumaDecoderParams : LumaDecoderParamsBase
  * Matroska container: http://www.matroska.org
  *
  */
-class LumaDecoder : public LumaDecoderBase
+class LUMA_DEC_EXPORT LumaDecoder : public LumaDecoderBase
 {
 public:
     LumaDecoder(const char *inputFile = NULL, bool verbose = 0);

--- a/include/luma/luma_encoder.h
+++ b/include/luma/luma_encoder.h
@@ -49,6 +49,16 @@
 #ifndef LUMA_ENCODER_H
 #define LUMA_ENCODER_H
 
+#ifdef _WINDOWS
+#ifdef luma_encoder_EXPORTS
+#define LUMA_ENC_EXPORT __declspec(dllexport)
+#else
+#define LUMA_ENC_EXPORT __declspec(dllimport)
+#endif
+#else
+#define LUMA_ENC_EXPORT
+#endif
+
 #include "luma_quantizer.h"
 #include "mkv_interface.h"
 #include "luma_frame.h"
@@ -78,7 +88,7 @@ struct LumaEncoderParamsBase
  * LumaEncoderBase provides the virtual interface for encoding of HDR video.
  *
  */
-class LumaEncoderBase
+class LUMA_ENC_EXPORT LumaEncoderBase
 {
 public:
     virtual bool initialize(const char *outputFile, 
@@ -130,7 +140,7 @@ struct LumaEncoderParams : LumaEncoderParamsBase
  * Matroska container: http://www.matroska.org
  *
  */
-class LumaEncoder : public LumaEncoderBase
+class LUMA_ENC_EXPORT LumaEncoder : public LumaEncoderBase
 {
 public:
     LumaEncoder();


### PR DESCRIPTION
Resolved MSVC build failures raised in issue #3, mostly caused by dynamic linking and missing __declspec definitions.